### PR TITLE
Add Colorio to Python section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,8 @@ Inspired by the __[awesome](https://github.com/sindresorhus/awesome)__ list. Ple
 
 ### Python
 
-- [Colorspacious](http://colorspacious.readthedocs.io/) - Easy to use Python library for performing colourspace conversions.
+- [Colorio](https://github.com/nschloe/colorio) - Even more up-to-date library than Colorspacious below.
+- [Colorspacious](http://colorspacious.readthedocs.io/) - Easy to use (but slightly older) library for performing colourspace conversions.
 - [Colour](https://www.colour-science.org/) - Package implementing a comprehensive number of colour theory transformations and algorithms.
 - [python-colormath](http://python-colormath.readthedocs.io/) - Abstracts common colour math operations.
 


### PR DESCRIPTION
The Colorspacious Python library is good but it doesn't include more recent models than CAM02-UCS such as CAM-16, Jzazbz, ICtCp etc. Colorio supports these.

The Colorspacious author clearly states inability to update the library:
https://github.com/njsmith/colorspacious/issues/10
https://github.com/njsmith/colorspacious/issues/13

So definitely Colorio should be mentioned above Colorspacious as it is better than the letter.

<!-- Thank you for your contribution to awesome-colour! Please replace the {...} templates with the relevant information. -->

## Please describe your suggestion and why should it be included?

{...}

## Does your pull request adheres to the [contributing guidelines](../contributing.md)?

- [x] Yes 🙌
- [ ] No

#### If no, please describe the reason:

{...}
